### PR TITLE
Httpheaders

### DIFF
--- a/docs/detailed-guide/docker.rst
+++ b/docs/detailed-guide/docker.rst
@@ -49,7 +49,7 @@ Then build and run the container from the command line as follows:
 
 .. code-block:: console
 
-    docker build -t docker_pyas2 . && docker run -p 8000:8000 docker_pyas2
+    $ docker build -t docker_pyas2 . && docker run -p 8000:8000 docker_pyas2
 
 
 In case the files on the host file system should be used, connect the directory to the host by
@@ -57,6 +57,6 @@ running to docker run command with the -v option:
 
 .. code-block:: console
 
-    docker build -t docker_pyas2 . && docker run -p 8000:8000 -v $PWD/django_pyas2:/django_pyas2 docker_pyas2
+    $ docker build -t docker_pyas2 . && docker run -p 8000:8000 -v $PWD/django_pyas2:/django_pyas2 docker_pyas2
 
 

--- a/docs/detailed-guide/extending.rst
+++ b/docs/detailed-guide/extending.rst
@@ -15,7 +15,7 @@ In the django_pyas2 project directory invoke the script as follows:
 
 .. code-block:: console
 
-    python manage.py startapp extend_pyas2
+    $ python manage.py startapp extend_pyas2
 
 
 This has now created a new directory containing files that may be used for apps:
@@ -70,7 +70,7 @@ command:
 
 .. code-block:: console
 
-    python manage.py filewatcher
+    $ python manage.py filewatcher
 
 
 .. code-block:: python

--- a/pyas2/views.py
+++ b/pyas2/views.py
@@ -10,6 +10,7 @@ from django.utils.translation import ugettext as _
 from django.urls import reverse_lazy
 from django.views import View
 from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.clickjacking import xframe_options_exempt
 from django.views.generic import FormView
 from pyas2lib import Message as As2Message
 from pyas2lib import Mdn as As2Mdn
@@ -64,6 +65,7 @@ class ReceiveAs2Message(View):
         if partner:
             return partner.as2partner
 
+    @xframe_options_exempt
     @csrf_exempt
     def post(self, request, *args, **kwargs):
 


### PR DESCRIPTION
Django middleware used in example as well as activated by default ( 'django.middleware.clickjacking.XFrameOptionsMiddleware' ), is adding X-Frame-Options to the AS2 response and this is, as per partner information from IBM, not a compliant header. 

Therefore added @xframe_options_exempt decorator to handling post request. 

