### PR TITLE
Add post_receive and post_send signals

### DIFF
--- a/pyas2/signals.py
+++ b/pyas2/signals.py
@@ -1,0 +1,4 @@
+from django.dispatch import Signal
+
+post_receive = Signal(providing_args=["message", "full_filename"])
+post_send = Signal(providing_args=["message"])

--- a/pyas2/tests/test_signals.py
+++ b/pyas2/tests/test_signals.py
@@ -1,0 +1,62 @@
+from unittest.mock import Mock
+
+import pytest
+
+from pyas2.models import Message, Partner
+from pyas2.signals import post_send, post_receive
+from pyas2.utils import run_post_send, run_post_receive
+
+
+@pytest.mark.django_db
+class TestPostReceiveSignal:
+
+    @pytest.fixture
+    def partner(self):
+        return Partner.objects.create(
+            name='AS2 Client',
+            as2_name='as2client',
+            target_url='http://localhost:8080/pyas2/as2receive',
+            compress=False,
+            mdn=False,
+        )
+
+    @pytest.fixture
+    def message(self, partner):
+        return Message.objects.create(partner=partner)
+
+    def test_run_post_receive_triggers_signal(self, message):
+        callback = Mock()
+        full_filename = "dummy_full_name"
+
+        post_receive.connect(callback)
+        run_post_receive(message, full_filename)
+        post_receive.disconnect(callback)
+
+        callback.assert_called_once_with(message=message, full_filename=full_filename, sender=Message, signal=post_receive)
+
+
+@pytest.mark.django_db
+class TestPostSendSignal:
+
+    @pytest.fixture
+    def partner(self):
+        return Partner.objects.create(
+            name='AS2 Client',
+            as2_name='as2client',
+            target_url='http://localhost:8080/pyas2/as2receive',
+            compress=False,
+            mdn=False,
+        )
+
+    @pytest.fixture
+    def message(self, partner):
+        return Message.objects.create(partner=partner)
+
+    def test_run_post_send_triggers_signal(self, message):
+        callback = Mock()
+
+        post_send.connect(callback)
+        run_post_send(message)
+        post_send.disconnect(callback)
+
+        callback.assert_called_once_with(message=message, sender=Message, signal=post_send)

--- a/pyas2/utils.py
+++ b/pyas2/utils.py
@@ -4,6 +4,8 @@ import os
 import time
 from string import Template
 
+from pyas2.signals import post_send, post_receive
+
 logger = logging.getLogger('pyas2')
 
 
@@ -34,6 +36,10 @@ def run_post_send(message):
     """ Execute command after successful send, can be used to notify
     successful sends """
 
+    # First we trigger the signal in case any app is listening
+    from pyas2.models import Message
+    post_send.send(sender=Message, message=message)
+
     command = message.partner.cmd_send
     if command:
         logger.debug('Execute post successful send command %s' % command)
@@ -54,6 +60,10 @@ def run_post_send(message):
 def run_post_receive(message, full_filename):
     """ Execute command after successful receive, can be used to call the
     edi program for further processing"""
+
+    # First we trigger the signal in case any app is listening
+    from pyas2.models import Message
+    post_receive.send(sender=Message, message=message, full_filename=full_filename)
 
     command = message.partner.cmd_receive
     if command:


### PR DESCRIPTION
This PR adds two signals `post_receive` and `post_send`. They are dispatched every time the `run_post_receive` and `run_post_send` are called. This helps in case we already have our logic inside the same project, therefore not needing to call a shell command and just hook receivers to these signals.