### PR TITLE
Protect download endpoint and fix it for some database systems

### DIFF
--- a/pyas2/tests/test_views.py
+++ b/pyas2/tests/test_views.py
@@ -1,0 +1,35 @@
+from django.contrib.auth.models import User
+from django.test import TestCase, Client
+from django.urls import reverse
+
+from pyas2.models import PublicCertificate
+
+
+class TestDownloadFileView(TestCase):
+    def setUp(self):
+        self.user = User.objects.create(username="dummy")
+        with open("pyas2/tests/fixtures/client_public.pem", "rb") as fp:
+            self.cert = PublicCertificate.objects.create(
+                name="test-cert", certificate=fp.read()
+            )
+
+    def test_view_is_protected(self):
+        client = Client()
+        response = client.get(
+            reverse("download-file", kwargs={"obj_type": "public_cert", "obj_id": "1"})
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(response.url.startswith("/accounts/login/"))
+
+    def test_download_public_certificate(self):
+        client = Client()
+        client.force_login(self.user)
+
+        response = client.get(
+            reverse(
+                "download-file",
+                kwargs={"obj_type": "public_cert", "obj_id": self.cert.id},
+            )
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(bytes(self.cert.certificate), response.content)

--- a/pyas2/urls.py
+++ b/pyas2/urls.py
@@ -1,4 +1,5 @@
 from django.conf.urls import url
+from django.contrib.auth.decorators import login_required
 
 from pyas2 import views
 

--- a/pyas2/urls.py
+++ b/pyas2/urls.py
@@ -9,5 +9,5 @@ urlpatterns = [
     url(r'^as2receive', views.ReceiveAs2Message.as_view(), name="as2-receive"),
     url(r'^as2send/', views.SendAs2Message.as_view(), name="as2-send"),
     url(r'^download/(?P<obj_type>.+)/(?P<obj_id>.+)/',
-        views.DownloadFile.as_view(), name='download-file'),
+        login_required(views.DownloadFile.as_view()), name='download-file'),
 ]

--- a/pyas2/views.py
+++ b/pyas2/views.py
@@ -249,6 +249,7 @@ class DownloadFile(View):
             disposition_type = 'attachment'
             response['Content-Disposition'] = disposition_type + '; filename=' + filename
             response.write(file_content)
+            response.write(bytes(file_content))
             return response
         else:
             raise Http404()

--- a/pyas2/views.py
+++ b/pyas2/views.py
@@ -248,7 +248,6 @@ class DownloadFile(View):
             response = HttpResponse(content_type='application/x-pem-file')
             disposition_type = 'attachment'
             response['Content-Disposition'] = disposition_type + '; filename=' + filename
-            response.write(file_content)
             response.write(bytes(file_content))
             return response
         else:


### PR DESCRIPTION
This PR fixes 2 issues:

The most important one is that the download view is unprotected and because the certificate id is serial it makes it very easy for an attacker to download the certificates without any authentication.

The second fix is that for some types of databases the download won't work because it will return a memory pointer instead of the actual content. As listed here: https://code.djangoproject.com/ticket/27813