### PR TITLE
Changes to duplicate handling

### DIFF
--- a/pyas2/settings.py
+++ b/pyas2/settings.py
@@ -20,3 +20,6 @@ ASYNC_MDN_WAIT = APP_SETTINGS.get("ASYNC_MDN_WAIT", 30)
 
 # Max number of days worth of messages to be saved in archive
 MAX_ARCH_DAYS = APP_SETTINGS.get("MAX_ARCH_DAYS", 30)
+
+# Send positive MDN when duplicate message is received
+ERROR_ON_DUPLICATE = APP_SETTINGS.get("ERROR_ON_DUPLICATE", True)

--- a/pyas2/tests/test_advanced.py
+++ b/pyas2/tests/test_advanced.py
@@ -261,6 +261,61 @@ class AdvancedTestCases(TestCase):
         )
         self.assertEqual(out_message.status, "E")
 
+    @mock.patch("requests.post")
+    def test_duplicate_success(self, mock_request):
+        with override_settings(PYAS2={"ERROR_ON_DUPLICATE": False}):
+            importlib.reload(settings)
+            partner = Partner.objects.create(
+                name="AS2 Server",
+                as2_name="as2server",
+                target_url="http://localhost:8080/pyas2/as2receive",
+                signature="sha1",
+                signature_cert=self.server_crt,
+                encryption="tripledes_192_cbc",
+                encryption_cert=self.server_crt,
+                mdn=True,
+                mdn_mode="SYNC",
+                mdn_sign="sha1",
+            )
+
+            # Send the message once
+            as2message = As2Message(
+                sender=self.organization.as2org, receiver=partner.as2partner
+            )
+            as2message.build(
+                self.payload,
+                filename="testmessage.edi",
+                subject=partner.subject,
+                content_type=partner.content_type,
+            )
+            in_message, _ = Message.objects.create_from_as2message(
+                as2message=as2message, payload=self.payload, direction="OUT", status="P"
+            )
+
+            mock_request.side_effect = SendMessageMock(self.client)
+            in_message.send_message(as2message.headers, as2message.content)
+
+            # Check the status of the message
+            self.assertEqual(in_message.status, "S")
+            out_message = Message.objects.get(
+                message_id=in_message.message_id, direction="IN"
+            )
+            self.assertEqual(out_message.status, "S")
+
+            # send it again to, should not cause duplicate error
+            in_message.send_message(as2message.headers, as2message.content)
+
+            # Make sure out message was created
+            self.assertEqual(in_message.status, "S")
+            out_message = Message.objects.get(
+                message_id=in_message.message_id + "_duplicate", direction="IN"
+            )
+            self.assertEqual(out_message.status, "S")
+
+        with override_settings(PYAS2={"ERROR_ON_DUPLICATE": True}):
+            importlib.reload(settings)
+            self.assertEqual(settings.ERROR_ON_DUPLICATE, True)
+
     def test_org_missing_error(self):
         # Create the client partner and send the command
         partner = Partner.objects.create(


### PR DESCRIPTION
Function to identify for earlier duplicate changed to check for status "S" or "P". 
Adding new setting ERROR_ON_DUPLICATE with default value True to preserve how application behaves now. If False, duplicate messages will be handled like success messages, but message_id to still have _duplicate added to it.

Currently, if no error is created for duplicate, the content of the message is stored once more. So if this should not happen, then various options should be checked: 
pyas2lib would have to be adjusted to "continue on duplicate" and let django-pyas2 decide what it wants to do with a duplicate message - maybe by adding another status "D" that could then be used to decide if file should be stored or not. 
Or have pyas2lib receive options what to do on duplicate.