### PR TITLE
Use orig_message_id as Message ID for MDN if no message_id was provid…

### DIFF
--- a/pyas2/models.py
+++ b/pyas2/models.py
@@ -535,7 +535,7 @@ class MdnManager(models.Manager):
         # Check for message-id in MDN.
         if as2mdn.message_id is None:
             message_id = as2mdn.orig_message_id
-            logger.debug(
+            logger.warning(
                 f"Received MDN response without a message-id. Using original "
                 f"message-id as ID instead: {message_id}"
             )

--- a/pyas2/models.py
+++ b/pyas2/models.py
@@ -534,7 +534,7 @@ class MdnManager(models.Manager):
         mdn, _ = self.update_or_create(
             message=message,
             defaults=dict(
-                mdn_id=as2mdn.message_id,
+                mdn_id=as2mdn.message_id if as2mdn.message_id is not None else as2mdn.orig_message_id,
                 status=status,
                 signed=signed,
                 return_url=return_url,

--- a/pyas2/models.py
+++ b/pyas2/models.py
@@ -531,13 +531,21 @@ class MdnManager(models.Manager):
     def create_from_as2mdn(self, as2mdn, message, status, return_url=None):
         """Create the MDN from the pyas2lib's MDN object"""
         signed = True if as2mdn.digest_alg else False
+
+        # Check for message-id in MDN.
+        if as2mdn.message_id is None:
+            message_id = as2mdn.orig_message_id
+            logger.debug(
+                f"Received MDN response without a message-id. Using original "
+                f"message-id as ID instead: {message_id}"
+            )
+        else:
+            message_id = as2mdn.message_id
+
         mdn, _ = self.update_or_create(
             message=message,
             defaults=dict(
-                mdn_id=as2mdn.message_id if as2mdn.message_id is not None else as2mdn.orig_message_id,
-                status=status,
-                signed=signed,
-                return_url=return_url,
+                mdn_id=message_id, status=status, signed=signed, return_url=return_url,
             ),
         )
         filename = f"{uuid4()}.mdn"

--- a/pyas2/tests/test_advanced.py
+++ b/pyas2/tests/test_advanced.py
@@ -5,6 +5,7 @@ from unittest import mock
 from django.test import Client, override_settings
 from django.test import TestCase
 from pyas2lib import Message as As2Message
+from pyas2lib import Mdn as As2Mdn
 
 from pyas2 import settings
 from pyas2.models import Message
@@ -421,6 +422,31 @@ class AdvancedTestCases(TestCase):
         self.assertTrue(
             "Failed to verify message signature" in out_message.detailed_status
         )
+
+    def test_missing_message_id(self):
+        # Create the client partner and send the command
+        partner = Partner.objects.create(
+            name="AS2 Server",
+            as2_name="as2server",
+            target_url="http://localhost:8080/pyas2/as2receive",
+            signature="sha1",
+            signature_cert=self.server_crt,
+            encryption="tripledes_192_cbc",
+            encryption_cert=self.server_crt,
+            mdn=True,
+            mdn_mode="ASYNC",
+            mdn_sign="sha1",
+        )
+        out_message = self.build_and_send(partner)
+
+        # Create MDN object without message_id
+        in_message = As2Mdn()
+        in_message.orig_message_id = out_message.message_id
+        in_message.message_id = None
+        mdn_message = Mdn.objects.create_from_as2mdn(in_message, out_message, "R")
+
+        # Check that original message id was used to store mdn_id
+        self.assertEqual(mdn_message.mdn_id, out_message.message_id)
 
     @mock.patch("requests.post")
     def build_and_send(self, partner, mock_request, smudge=False):


### PR DESCRIPTION
…ed (OpenText compatibility).

https://github.com/abhishek-ram/django-pyas2/issues/60
