### PR TITLE
update django-admin startproject sample command

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -11,7 +11,7 @@ Create a new ``django`` project
 
 .. code-block:: console
 
-    $ django-admin.py startproject django_pyas2 .
+    $ django-admin startproject django_pyas2 .
 
 Add ``pyas2`` to your ``INSTALLED_APPS`` setting.
 


### PR DESCRIPTION
on my installation, `django-admin.py` was not found, however `django-admin` was found. Is it possible the `.py` extension to django-admin is a copy-paste holdover from an earlier version?

```shell
(pyas2) bkc@laptop:~/src/pyas2$ django-admin.py startproject django_pyas2 .
django-admin.py: command not found
(pyas2) bkc@laptop:~/src/pyas2$ django-admin startproject django_pyas2 .
```