### PR TITLE
bump pyas2lib to 1.4.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(os.path.join(root, 'README.rst')) as f:
     README = f.read()
 
 install_requires = [
-    'pyas2lib==1.4.2',
+    'pyas2lib==1.4.3',
     'django>=2.2.18',
     'requests'
 ]


### PR DESCRIPTION
to avoid the OpenSSL_add_all_algorithms issue
and please create a new django_pyas2 release and make it available to pip as latest. 
I've spent so much time dealing with all the issues fixed in pyas2lib up to version 1.4.3 with EVP_PKEY_size errors, OPENSSL all_algorithms, etc... 