### PR TITLE
In Django >=4.2.14, the filepath for storing the files is not allowed t…

### DIFF
--- a/pyas2/models.py
+++ b/pyas2/models.py
@@ -6,6 +6,7 @@ import traceback
 from email.parser import HeaderParser
 from uuid import uuid4
 
+import django
 import requests
 from django.core.files.base import ContentFile
 from django.core.files.storage import default_storage
@@ -23,6 +24,21 @@ from pyas2lib.utils import extract_certificate_info
 
 from pyas2 import settings
 from pyas2.utils import run_post_send
+
+# Check if running Django >= 4.2
+if django.VERSION >= (4, 2):
+    try:
+        from django.core.files.storage import storages
+
+        as2files_storage = storages[
+            "as2files"
+        ]  # Use 'as2files' storage if defined in Django 4.2+
+    except KeyError:
+        # If 'as2files' is not configured, fallback to default storage
+        as2files_storage = default_storage
+else:
+    # In Django 4.1 or lower, fallback to default storage
+    as2files_storage = default_storage
 
 logger = logging.getLogger("pyas2")
 
@@ -349,18 +365,14 @@ class MessageManager(models.Manager):
         # Save the payload to the inbox folder
         full_filename = None
         if direction == "IN" and status == "S":
-            if settings.DATA_DIR:
-                dirname = os.path.join(
-                    settings.DATA_DIR, "messages", organization, "inbox", partner
-                )
-            else:
-                dirname = os.path.join("messages", organization, "inbox", partner)
+            dirname = os.path.join("messages", organization, "inbox", partner)
             if not message.partner.keep_filename or not filename:
                 filename = f"{message.message_id}.msg"
-            full_filename = default_storage.generate_filename(
+
+            full_filename = as2files_storage.generate_filename(
                 posixpath.join(dirname, filename)
             )
-            default_storage.save(name=full_filename, content=ContentFile(payload))
+            as2files_storage.save(name=full_filename, content=ContentFile(payload))
 
         return message, full_filename
 

--- a/pyas2/models.py
+++ b/pyas2/models.py
@@ -13,13 +13,10 @@ from django.core.files.storage import default_storage
 from django.db import models
 from django.utils import timezone
 from django.utils.translation import gettext as _
-
-from pyas2lib import (
-    Mdn as As2Mdn,
-    Message as As2Message,
-    Organization as As2Organization,
-    Partner as As2Partner,
-)
+from pyas2lib import Mdn as As2Mdn
+from pyas2lib import Message as As2Message
+from pyas2lib import Organization as As2Organization
+from pyas2lib import Partner as As2Partner
 from pyas2lib.utils import extract_certificate_info
 
 from pyas2 import settings
@@ -28,7 +25,7 @@ from pyas2.utils import run_post_send
 # Check if running Django >= 4.2
 if django.VERSION >= (4, 2):
     try:
-        from django.core.files.storage import storages
+        from django.core.files.storage import storages  # noqa: E0611
 
         as2files_storage = storages[
             "as2files"

--- a/pyas2/settings.py
+++ b/pyas2/settings.py
@@ -1,5 +1,6 @@
 import os
 
+import django
 from django.conf import settings
 
 APP_SETTINGS = getattr(settings, "PYAS2", {})
@@ -20,3 +21,11 @@ ASYNC_MDN_WAIT = APP_SETTINGS.get("ASYNC_MDN_WAIT", 30)
 
 # Max number of days worth of messages to be saved in archive
 MAX_ARCH_DAYS = APP_SETTINGS.get("MAX_ARCH_DAYS", 30)
+
+if django.VERSION >= (4, 2) and "as2files" not in settings.STORAGES:
+    settings.STORAGES["as2files"] = {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+        "OPTIONS": {
+            "location": DATA_DIR,
+        },
+    }


### PR DESCRIPTION
…o be an absolute path.

@abhishek-ram : we don't have this problem when DATA_DIR is not set. This is however a problem when DATA_DIR is set, even if it is set to MEDIA_ROOT (or vice versa). I therefore implemented an own storage config called "as2files". 

In earlier version of Django it was not a problem when DATA_DIR was set to match MEDIA_ROOT as well, but that actually required this to be specifically set and was not transparent to the user. 

Honestly, not sure if there is collateral - i have tested my scenarios and it works also be backward compatible. But maybe I am missing something. 

More on the issue is here: 
https://github.com/advisories/GHSA-9jmf-237g-qf46
and the allow_relative_path function in https://github.com/django/django/blame/main/django/core/files/utils.py 

anyway, this is a suggestion